### PR TITLE
SSL for dev sites

### DIFF
--- a/config/lamp/etc-apache2-sites-available-devserver-ssl.j2
+++ b/config/lamp/etc-apache2-sites-available-devserver-ssl.j2
@@ -34,4 +34,7 @@
     Satisfy Any
   </Directory>
 
+  SSLEngine on
+  SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem
+  SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 </VirtualHost>

--- a/config/lamp/lamp.yml
+++ b/config/lamp/lamp.yml
@@ -72,6 +72,9 @@
 - name: Apache | Enable Apache vhost_alias module
   action: command a2enmod vhost_alias creates=/etc/apache2/mods-enabled/vhost_alias.load
 
+- name: Apache | Enable Apache ssl module
+  action: command a2enmod ssl creates=/etc/apache2/mods-enabled/ssl.load
+
 - name: Apache | Main configuration file
   action: template src=lamp/etc-apache2-apache2-conf.j2 dest=/etc/apache2/apache2.conf
 
@@ -81,11 +84,17 @@
 - name: Apache | Configuration file for our devserver site
   action: template src=lamp/etc-apache2-sites-available-devserver.j2 dest=/etc/apache2/sites-available/devserver
 
+- name: Apache | Configuration file for https devserver site
+  action: template src=lamp/etc-apache2-sites-available-devserver-ssl.j2 dest=/etc/apache2/sites-available/devserver-ssl
+
 - name: Apache | Disable the default site
   action: command a2dissite default removes=/etc/apache2/sites-enabled/default
 
 - name: Apache | Enable our new devserver site
   action: command a2ensite devserver creates=/etc/apache2/sites-enabled/devserver
+
+- name: Apache | Enable our new https devserver site
+  action: command a2ensite devserver-ssl creates=/etc/apache2/sites-enabled/devserver-ssl
 
 - name: Apache | Robots.txt file that prevents search engines from spidering dev site.
   action: copy src=lamp/var-www-robots-txt dest=/var/www/robots.txt


### PR DESCRIPTION
Enables the SSL Apache module and adds an SSL entry for the dev servers.
Tested locally on vagrant and it worked.
