### PR TITLE
removed sass and related gems

### DIFF
--- a/roles/web/tasks/ruby.yml
+++ b/roles/web/tasks/ruby.yml
@@ -9,15 +9,6 @@
 - name: Ruby | Install Sass and all ruby gems
   action: gem name=$item state=latest
   with_items:
-    - sass
-    - compass
-    - singularitygs
-    - susy
-    - toolkit
-    - respond-to
-    - breakpoint
-    - compass-aurora
-    - color-schemer
     - bundler
 #    - github-pages This cannot be added until we have ruby 1.9.3
 


### PR DESCRIPTION
Talked with @elliotttf and @rupl they feel that instead of updating this in the playbooks we should just install bundler and let it handle stuff for individual projects from there. 
