### PR TITLE
Address Vagrant sync folders syntax change

### DIFF
--- a/vagrant/VagrantFile
+++ b/vagrant/VagrantFile
@@ -19,8 +19,8 @@ Vagrant.configure("2") do |config|
     # Shared folders through NFS. This is supported in Mac and Linux. Windows may have
     # issues, see Vagrant site for documentation.
     dev_config.vm.network :private_network, ip: "10.1.0.10"
-    dev_config.vm.synced_folder "../", "/home/vagrant/playbooks", :nfs => true
-    dev_config.vm.synced_folder "~/www", "/home/vagrant/www", :nfs => true, :create => true
+    dev_config.vm.synced_folder "../", "/home/vagrant/playbooks"
+    dev_config.vm.synced_folder "~/www", "/home/vagrant/www"
 
     dev_config.vm.provision :shell, :path => "provision/ansible-setup.sh"
     dev_config.vm.provision :shell, :path => "provision/local-dev-setup.sh"


### PR DESCRIPTION
This PR changes the Vagrant file to use the new vagrant folder sync syntax.

It also removes NFS as the type to deal with a problem introduced by new vagrant, virtual box and a bad networking from Mavericks

@elliotttf @ChinggizKhan What do you think?
