### PR TITLE
Copied the meat of the Drush ansible Role.

### DIFF
--- a/roles/web/defaults/main.yml
+++ b/roles/web/defaults/main.yml
@@ -23,6 +23,7 @@ php_xdebug_remote_enable: 0
 php_xdebug_max_nesting_level: 200
 
 # Drush
+composer_path: /usr/local/bin/composer
 drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: 6.4.0

--- a/roles/web/tasks/drush.yml
+++ b/roles/web/tasks/drush.yml
@@ -12,6 +12,7 @@
     dest={{ drush_install_path }}
     version={{ drush_version }}
     update={{ drush_keep_updated }}
+    force=no
 
 - name: Install Drush dependencies with Composer.
   shell: >


### PR DESCRIPTION
@iamcarrico This looks like the best way for us to approach the drush issue. I'd rather use the Galaxy role, but we can't without patching his php role to support both php-fpm and Apache. Right now his role only supports one or the other.
