### PR TITLE
Added documentation on missing setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Start by installing [Homebrew](http://brew.sh/), a package manager for OS X. Add
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
+Next install the [Homebrew](http://brew.sh/) extension [Cask](http://caskroom.io/), an application package manager that deals with prebuilt binaries for desktop applications. Additional instructions can be found in the [documentation](https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md).
+
+    brew install caskroom/cask/brew-cask
+
 Next, install VirtualBox.
 
     brew cask install virtualbox


### PR DESCRIPTION
While trying to get Vivek up and running, we realized a step was missing - the explicit setup of Cask, which isn't bundled with Homebrew, but necessary to get Vagrant and Virtualbox installed.
