### PR TITLE
Drupal 8 max nesting level change

### DIFF
--- a/roles/web/defaults/main.yml
+++ b/roles/web/defaults/main.yml
@@ -20,7 +20,7 @@ php_memory_limit: '192M'
 php_cgi_fix_pathinfo: '0'
 php_short_open_tag: 'Off'
 php_xdebug_remote_enable: 0
-php_xdebug_max_nesting_level: 200
+php_xdebug_max_nesting_level: 256
 
 # Drush
 composer_path: /usr/local/bin/composer


### PR DESCRIPTION
D8 requires a debug nesting level of 256 for it not to break, this does that.
